### PR TITLE
add remote for {nter}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,3 +21,4 @@ Imports:
     tidyverse
 Remotes: 
     hadley/emo
+    JohnCoene/nter

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,5 +20,5 @@ Imports:
     shiny,
     tidyverse
 Remotes: 
-    hadley/emo
+    hadley/emo,
     JohnCoene/nter


### PR DESCRIPTION
Initial attempt to build the chapter notes for Federica's presentation failed because the package {nter} couldn't be installed. It is a remote package. The github details have been added to `Remotes:` section of DESCRIPTION.